### PR TITLE
fix lots of rainbow color calculations

### DIFF
--- a/docs/sources.ipynb
+++ b/docs/sources.ipynb
@@ -315,13 +315,13 @@
    "outputs": [],
    "source": [
     "ax = None\n",
-    "for T in np.arange(1000, 20000, 500) * u.K:\n",
+    "for T in np.arange(1000, 20000, 1000) * u.K:\n",
     "    t = Thermal(T)\n",
     "    ax = t.plot(ax)\n",
     "plt.yscale(\"log\")\n",
     "plt.xscale(\"log\")\n",
     "plt.xlim(100, 1000)\n",
-    "plt.ylim(1e12, 1e26);"
+    "plt.ylim(1e12, 1e28);"
    ]
   },
   {
@@ -329,7 +329,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can plot the spectrum with a rainbow included, to directly visualize the amount of visible light of particular colors."
+    "We can plot the spectrum with a rainbow included filling in the space under the curve, to directly visualize the amount of visible light of particular colors."
    ]
   },
   {
@@ -346,7 +346,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Or we can plot as the spectrum that would be seen visually through a slit spectroscope."
+    "Or we can plot as the spectrum that would be seen visually through a slit spectroscope. In these visualizations, the y-axis is meaningless; all that matters is the brightness at each wavelength relative to the reference rainbow above (which represents approximately uniform brightness across wavelength). "
    ]
   },
   {
@@ -417,7 +417,7 @@
     "\n",
     "# tidy up the plot\n",
     "plt.xlabel(\"Temperature (K)\")\n",
-    "plt.ylabel(\"Surface Flux $(W/m^2)$\");"
+    "plt.ylabel(\"Surface Flux (W/m$^2$)\");"
    ]
   }
  ],

--- a/docs/stars.ipynb
+++ b/docs/stars.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "0e72a610",
    "metadata": {},
@@ -17,15 +18,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from rainbowconnection.sources.phoenix import *"
+    "from rainbowconnection import *"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "61e2ecbe",
    "metadata": {},
    "source": [
-    "(Add instructions for downloading spectral library.)"
+    "The first time you try to make a stellar spectrum, it should try to automatically download the library files you need for it; you'll need to be connected to the internet for this step. If you try to generate a very high resolution stellar spectrum, it may take a long time for those files to download!"
    ]
   },
   {
@@ -35,15 +37,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s = Star(teff=3700 * u.K, radius=0.75 * u.Rsun, mass=0.5 * u.Msun, R=5e4)"
+    "s = Star(teff=3700 * u.K, radius=0.75 * u.Rsun, mass=0.5 * u.Msun, R=10000)"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "a6b6cf3b",
    "metadata": {},
    "source": [
-    "There are a few ways we can plot this spectrum"
+    "Let's plot it, both as a 1D spectrum and as it might appear through a visual spectroscope."
    ]
   },
   {
@@ -53,24 +56,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s.plot()\n",
-    "s.plot_as_slit_rainbow();"
+    "s.plot();"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e6b7d376",
+   "id": "4e8f8f49",
    "metadata": {},
    "outputs": [],
    "source": [
-    "xlim = [700, 720] * u.nm\n",
-    "s.plot()\n",
-    "plt.xlim(*xlim)\n",
-    "s.plot_as_slit_rainbow(xlim=xlim, dw=0.01 * u.nm);"
+    "s.plot_as_slit_rainbow();"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "bd2f1b86",
    "metadata": {},
@@ -81,26 +81,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a4147806",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "quantity_support();"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "961a162d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "w = s.wavelength()\n",
+    "w = s.wavelength\n",
     "f = s.spectrum()\n",
     "plt.plot(w, f);"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "8e9783cb",
    "metadata": {},
@@ -122,6 +113,14 @@
     "plt.plot(w_other, f_other)\n",
     "plt.xlim(695, 725);"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92781b71",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -140,7 +139,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://zkbt.github.com/rainbow-connection
 nav:
     - index.md
     - installation.ipynb
-    - light-sources.ipynb
+    - sources.ipynb
     - stars.ipynb
     - atmospheres.ipynb
     - sunsets.ipynb

--- a/rainbowconnection/imports.py
+++ b/rainbowconnection/imports.py
@@ -1,16 +1,20 @@
 from IPython import get_ipython
-get_ipython().magic(u'matplotlib inline')
+try:
+    if get_ipython().__class__.__name__ == 'ZMQInteractiveShell':
+        get_ipython().magic(u'matplotlib inline')
+except AttributeError:
+    pass
 
-import copy, pkg_resources, os, glob, warnings
-
-data_directory = pkg_resources.resource_filename("rainbowconnection", "data")
+import copy, inspect, os, glob, warnings
+package_directory = os.path.dirname(inspect.getfile(inspect.currentframe()))
+data_directory = os.path.join(package_directory, 'data')
 package_name = "rainbow-connection"
 
 import numpy as np
 import matplotlib.pyplot as plt
 
 plt.matplotlib.rcParams["figure.figsize"] = (8, 3)
-plt.matplotlib.rcParams["figure.dpi"] = 300
+plt.matplotlib.rcParams["figure.dpi"] = 100
 
 from astropy.io import ascii
 import astropy.units as u

--- a/rainbowconnection/resampletools.py
+++ b/rainbowconnection/resampletools.py
@@ -99,7 +99,7 @@ def fluxconservingresample(
     yout = np.diff(cdfout)
 
     if visualize:
-        fi, (ax_cdf, ax_pdf) = plt.subplots(2, 1, sharex=True, figsize=(9, 6))
+        fi, (ax_cdf, ax_pdf) = plt.subplots(2, 1, sharex=True, figsize=(9, 6), constrained_layout=True)
         inkw = dict(
             color="black",
             alpha=1,
@@ -171,7 +171,6 @@ def fluxconservingresample(
                 "Pausing a moment to check on interpolation; press return to continue."
             )
 
-        plt.tight_layout(rect=[0.0, 0.0, 0.67, 1])
         print("{:>6} = {:.5f}".format("Actual", np.sum(yin)))
         print(
             "{:>6} = {:.5f}".format(

--- a/rainbowconnection/sources/spectrum.py
+++ b/rainbowconnection/sources/spectrum.py
@@ -576,6 +576,7 @@ class Spectrum:
     def plot_as_rainbow(
         self,
         ax=None,
+        wavelength=None,
         rainbow=True,
         color="auto",
         style="dark_background",
@@ -627,9 +628,9 @@ class Spectrum:
             # setup the basic axes
             ax = setup_axes_with_rainbow(ax=ax, rainbow=rainbow, figsize=figsize)
 
-            # make sure at least some wavelengths are defined
-            w = np.arange(330, 760, 1) * u.nm
+            w = self.get_wavelength(wavelength)
             f = self.spectrum(w)
+
             # KLUDGE?
             norm = np.max(f.value[(w > 400 * u.nm) & (w < 685 * u.nm)]) / 100
             if foreground:
@@ -654,6 +655,7 @@ class Spectrum:
     def plot_as_slit_rainbow(
         self,
         ax=None,
+        wavelength=None,
         rainbow=True,
         style="dark_background",
         figsize=None,
@@ -697,13 +699,11 @@ class Spectrum:
             ax = setup_axes_with_rainbow(ax=ax, rainbow=rainbow, figsize=figsize)
 
             # make sure at least some wavelengths are defined
-            w = np.arange(
-                    xlim[0].to("nm").value, xlim[1].to("nm").value, dw.to("nm").value
-                )* u.nm
+            w = self.get_wavelength(wavelength)
             f = self.spectrum(w)
-
+            assert(np.shape(w) == np.shape(f))
             plot_as_slit_rainbow(
-                ax=ax, wavelength=w.to("nm").value, flux=f.value, **kwargs
+                ax=ax, wavelength=w.to_value("nm"), flux=f.value, **kwargs
             )
 
             # add the axis labels

--- a/rainbowconnection/tests/__init__.py
+++ b/rainbowconnection/tests/__init__.py
@@ -2,3 +2,4 @@ from .test_atmospheres import *
 from .test_lights import *
 from .test_resampling import *
 from .test_sunsets import *
+from .test_plots import * 

--- a/rainbowconnection/tests/test_plots.py
+++ b/rainbowconnection/tests/test_plots.py
@@ -1,0 +1,26 @@
+import rainbowconnection as rc
+import matplotlib.pyplot as plt
+import numpy as np
+import astropy.units as u
+from .directory import *
+
+def test_plots():
+    s = rc.Sun()
+    s.plot()
+    save("sun-plot.png")
+    s.plot_as_rainbow()
+    save("sun-plot-as-rainbow.png")
+    s.plot_as_slit_rainbow()
+    save("sun-plot-as-slit-rainbow.png")
+
+    xlim = (300,1000)
+    s = rc.Sun()
+    s.plot()
+    plt.xlim(*xlim)
+    save("sun-plot-zoom.png")
+    s.plot_as_rainbow()
+    plt.xlim(*xlim)
+    save("sun-plot-as-rainbow-zoom.png")
+    s.plot_as_slit_rainbow()
+    plt.xlim(*xlim)
+    save("sun-plot-as-slit-rainbow-zoom.png")

--- a/rainbowconnection/version.py
+++ b/rainbowconnection/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.9"
+__version__ = "0.0.10"
 
 
 def version():

--- a/setup.py
+++ b/setup.py
@@ -84,10 +84,11 @@ setup(
         "numpy",
         "scipy",
         "ipython",
-        "matplotlib>=3.0",
+        "matplotlib>=3.7.1", # 3.6 doesn't have RGB colormesh
         "jupyter",
         "astropy>=4.0",
         "colour-science>=0.4.2",
+        "chromatic-lightcurves>=0.4.5",
         "tqdm",
     ],
     # what version of Python is required?


### PR DESCRIPTION
The ways that `plot_as_rainbow` and `plot_as_slit_rainbow` worked were really fragile, relying on a uniform wavelength grid. This PR tries to fix that problem and allow non-uniform (including logarithmic) wavelength grids. Some tweaks could probably still be useful to boost efficiency and clarity.